### PR TITLE
viu: ignore `CARGO_TARGET_DIR` in `build()`

### DIFF
--- a/viu/PKGBUILD
+++ b/viu/PKGBUILD
@@ -16,7 +16,7 @@ sha512sums=('cb22d2d629020cf2ca52fc9ac8fc0a053998bd08db7c4096ae497ba45ecdbf0103a
 
 build() {
   cd "$pkgname-$pkgver"
-  cargo build --release --locked
+  env -u CARGO_TARGET_DIR cargo build --release --locked
 }
 
 check() {


### PR DESCRIPTION
If `CARGO_TARGET_DIR` is set, the binary gets built to there, but the `PKGBUILD` expects it to be in `target` directory. So `package()` will fail with the following message:
```
==> Starting package()...
install: cannot stat 'target/release/viu': No such file or directory
==> ERROR: A failure occurred in package().
```